### PR TITLE
Remove deprecated enabledForSite() element query option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Element Status Events Changelog
 
+## 2.0.1 - 2022-04-26
+- Remove deprecated `enabledForSite()` element query parameter
+
 ## 2.0.0 - 2019-03-28
 ### Added
 - Added event object `StatusChangeEvent` with access to element via `getElement()` and check methods:

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "putyourlightson/craft-element-status-events",
     "description": "Element status events extension for Craft CMS.",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "type": "yii2-extension",
     "homepage": "https://github.com/putyourlightson/craft-element-status-events",
     "license": "MIT",

--- a/src/commands/ScheduledElements.php
+++ b/src/commands/ScheduledElements.php
@@ -149,12 +149,11 @@ class ScheduledElements extends Controller
 
         // Entries published within time frame
         $entries = (Entry::find()
-            ->where(['not', ['postDate' => null]])
-            ->andWhere(['between', 'postDate', $rangeStart, $rangeEnd])
+            ->where(['between', 'postDate', $rangeStart, $rangeEnd])
             ->withStructure(false)
             ->orderBy(null)
-            ->anyStatus()
-            ->enabledForSite(true))->all();
+            ->status('live')
+        )->all();
 
         // Exclude manually published entries (postDate ≅ dateUpdated)
         return array_filter($entries, function (Entry $item) {
@@ -174,12 +173,10 @@ class ScheduledElements extends Controller
         // TODO: Support Product and other Elements with expiryDate
 
         return (Entry::find()
-            ->where(['not', ['expiryDate' => null]])
-            ->andWhere(['between', 'expiryDate', $rangeStart, $rangeEnd])
+            ->where(['between', 'expiryDate', $rangeStart, $rangeEnd])
             ->withStructure(false)
             ->orderBy(null)
-            ->anyStatus()
-            ->enabledForSite(true)
+            ->status('expired')
         )->all();
     }
 }


### PR DESCRIPTION
Hi @bencroker.

We use your plugin and noticed it is throwing a deprecation error related to element queries.

```
2022-04-26T08:07:18Z INFO (element-status[230]): Exception 'craft\errors\DeprecationException' with message 'The `enabledForSite` element query param has been deprecated. `status()` should be used instead.'
```

We have the setting to throw hard exception on deprecation errors in development/stating to make it easy to catch deprecation issues.

`enabledForSite()` is deprecated and anyStatus() which you are already calling seems to be the suitable replacement to provide the same query result.

The only consideration is anyStatus() was made available in Craft CMS 3.0.17, so you'd potentially have to bump the Craft CMS requirement in your module to ensure it's available, but given Craft CMS 3.0.17 is quite far back, I guess this should be OK?

I bumped the composer version in anticipation of releasing a minor version update to fix this the deprecation error.

Hope that's OK!
